### PR TITLE
Add a wait to prevent rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ async function sendMatrixNotification() {
     core.setOutput("eventId", eventId);
 
     for (let reaction of reactions) {
+        await wait(1000);
         await client.unstableApis.addReactionToEvent(roomId, eventId, reaction);
     }
 }


### PR DESCRIPTION
This may not be needed when https://github.com/turt2live/matrix-bot-sdk/issues/18 is closed, but in the meantime this might be the easiest compromise to get it working again.

Closes #1 